### PR TITLE
[feat] 예매 시 좌석 데이터 생성하도록 수정

### DIFF
--- a/metanet4/src/main/java/com/metanet/team4/common/TestDataUtils.java
+++ b/metanet4/src/main/java/com/metanet/team4/common/TestDataUtils.java
@@ -58,7 +58,7 @@ public class TestDataUtils {
     	
     	reservation.setMemberId(member.getId());
     	reservation.setPlayingId(1L);
-    	reservation.setSeatId(1L); // Todo 생성하고 넣는걸로 수정 해야함
+//    	reservation.setSeatId(1L); // Todo 생성하고 넣는걸로 수정 해야함
     	
     	reservationRepository.insertReservation(reservation);
     	

--- a/metanet4/src/main/java/com/metanet/team4/config/SecurityConfig.java
+++ b/metanet4/src/main/java/com/metanet/team4/config/SecurityConfig.java
@@ -75,7 +75,7 @@ public class SecurityConfig {
     @Bean
     public CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration configuration = new CorsConfiguration();
-        configuration.setAllowedOrigins(Arrays.asList("http://localhost:3000", "http://localhost:8080")); // ✅ 허용할 Origin 추가
+        configuration.setAllowedOrigins(Arrays.asList("http://localhost:3000", "http://localhost:8080", "http://metanetbhn.shop:8080", "https://metanetbhn.shop:443")); // ✅ 허용할 Origin 추가
         configuration.setAllowedMethods(Arrays.asList("GET", "POST", "PUT", "DELETE", "OPTIONS")); // ✅ OPTIONS 포함
         configuration.setAllowCredentials(true);
         configuration.setAllowedHeaders(Arrays.asList("Authorization", "Cache-Control", "Content-Type"));

--- a/metanet4/src/main/java/com/metanet/team4/payment/controller/ReservController.java
+++ b/metanet4/src/main/java/com/metanet/team4/payment/controller/ReservController.java
@@ -29,8 +29,9 @@ public class ReservController {
     @Operation(summary = "예매 상세 조회", description = "예매 ID를 기반으로 예매 상세 정보를 조회합니다.")
     @GetMapping("/{reservationId}")
     public ResponseEntity<ReservationDetailDto> getReservationDetail(
-            @Parameter(description = "예매 ID", required = true) @PathVariable Long reservationId) {
-        ReservationDetailDto response = reservService.getReservationDetail(reservationId);
+            @Parameter(description = "예매 ID", required = true) @PathVariable Long reservationId,
+            @Parameter(hidden = true) @Login Member member) {
+        ReservationDetailDto response = reservService.getReservationDetail(member.getId(), reservationId);
         return ResponseEntity.ok(response);
     }
 

--- a/metanet4/src/main/java/com/metanet/team4/payment/dao/IReservatoinRepository.java
+++ b/metanet4/src/main/java/com/metanet/team4/payment/dao/IReservatoinRepository.java
@@ -14,7 +14,7 @@ public interface IReservatoinRepository {
 	
     ReservationDetailDto getReservationDetail(Long reservationId);
     
-    Reservation getReervationByUserIdAndId(Long userId, Long reservationId);
+    Reservation getReservationByUserIdAndId(Long userId, Long reservationId);
     
     int updateTicketStatus(Long reservationId, Integer ticketStatus);
 }

--- a/metanet4/src/main/java/com/metanet/team4/payment/model/PaymentRequestDto.java
+++ b/metanet4/src/main/java/com/metanet/team4/payment/model/PaymentRequestDto.java
@@ -14,4 +14,5 @@ public class PaymentRequestDto {
 	
 	private Integer paymentAmount;
     private String ticketType; // 티켓 유형 (일반, 청소년 등)
+    private String seatNames; // 좌석 정보(E3, E4)
 }

--- a/metanet4/src/main/java/com/metanet/team4/payment/model/Reservation.java
+++ b/metanet4/src/main/java/com/metanet/team4/payment/model/Reservation.java
@@ -23,6 +23,5 @@ public class Reservation {
     
     private Long memberId;	// 멤버ID
     private Long playingId; // 상영ID
-    private Long seatId; 	// 좌석ID
     
 }

--- a/metanet4/src/main/java/com/metanet/team4/payment/model/Reservation.java
+++ b/metanet4/src/main/java/com/metanet/team4/payment/model/Reservation.java
@@ -1,9 +1,13 @@
 package com.metanet.team4.payment.model;
 
+import java.util.Date;
+import java.util.List;
+
+import com.metanet.team4.ticket.model.Seat;
+
 import lombok.Getter;
 import lombok.Setter;
 import lombok.ToString;
-import java.util.Date;
 
 
 @Getter
@@ -23,5 +27,6 @@ public class Reservation {
     
     private Long memberId;	// 멤버ID
     private Long playingId; // 상영ID
+    private List<Seat> seatList;
     
 }

--- a/metanet4/src/main/java/com/metanet/team4/payment/model/ReservationDetailDto.java
+++ b/metanet4/src/main/java/com/metanet/team4/payment/model/ReservationDetailDto.java
@@ -1,6 +1,9 @@
 package com.metanet.team4.payment.model;
 
 import java.util.Date;
+import java.util.List;
+
+import com.metanet.team4.ticket.model.Seat;
 
 import lombok.Getter;
 import lombok.Setter;
@@ -18,7 +21,7 @@ public class ReservationDetailDto {
 	private Date endTime;
 	private String cinemaName; // 영화관이름
 	private String screenName; // 상영관 이름
-	private String seatName;  // 좌석 이름
+	private List<Seat> seatList;  // 좌석 이름
 	private String ticketType; // 티켓 유형
 	private Long reservationCode; // 예매 코드
 

--- a/metanet4/src/main/java/com/metanet/team4/payment/service/PaymentService.java
+++ b/metanet4/src/main/java/com/metanet/team4/payment/service/PaymentService.java
@@ -1,7 +1,10 @@
 package com.metanet.team4.payment.service;
 
+import java.util.Arrays;
 import java.util.Date;
+import java.util.List;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
@@ -11,14 +14,15 @@ import com.metanet.team4.payment.dao.IReservatoinRepository;
 import com.metanet.team4.payment.model.PaymentRequestDto;
 import com.metanet.team4.payment.model.PaymentResponseDto;
 import com.metanet.team4.payment.model.Reservation;
+import com.metanet.team4.ticket.dao.ISeatRepository;
+import com.metanet.team4.ticket.model.Seat;
 
 import lombok.RequiredArgsConstructor;
-
 
 @Service
 @RequiredArgsConstructor
 public class PaymentService {
-	
+    
     @Value("${bootpay.api.application-id}")
     private String bootpayApplicationId;
 
@@ -26,26 +30,33 @@ public class PaymentService {
     private String bootpayPrivateKey;
 
     private final IReservatoinRepository reservationRepository;
+    private final ISeatRepository seatRepository;
 
     public PaymentResponseDto processPayment(PaymentRequestDto request, Member member) {
-    	
-    	Reservation reservation = new Reservation();
-    	reservation.setReservationTime(new Date());
-    	reservation.setReservationCode(generateUniqueReservationCode());
-    	
-    	reservation.setPaymentAmount(request.getPaymentAmount());
-    	reservation.setReceiptId(request.getReceiptId());
-    	reservation.setTicketType(request.getTicketType());
-    	reservation.setTicketStatus(1);
-    	
-    	reservation.setMemberId(member.getId());
-    	reservation.setPlayingId(request.getPlayingId());
-//    	reservation.setSeatId(1L); // Todo 생성하고 넣는걸로 수정 해야함
-    	
-    	reservationRepository.insertReservation(reservation);
-    	
-    	System.out.println("예매 정보 저장");
-    	
+        // 예약 정보 생성
+        Reservation reservation = new Reservation();
+        reservation.setReservationTime(new Date());
+        reservation.setReservationCode(generateUniqueReservationCode());
+        reservation.setPaymentAmount(request.getPaymentAmount());
+        reservation.setReceiptId(request.getReceiptId());
+        reservation.setTicketType(request.getTicketType());
+        reservation.setTicketStatus(1);
+        reservation.setMemberId(member.getId());
+        reservation.setPlayingId(request.getPlayingId());
+
+        reservationRepository.insertReservation(reservation);
+        System.out.println("예매 정보 저장 완료");
+
+        // 좌석 데이터 생성 및 저장
+        List<Seat> seats = parseSeatNames(request.getSeatNames(), request.getPlayingId(), reservation.getId());
+        if (!seats.isEmpty()) {
+        	for(Seat seat : seats) {
+                seatRepository.insertSeat(seat);
+        	}
+            System.out.println("좌석 정보 저장 완료: " + seats);
+        }
+
+        // 응답 생성
         PaymentResponseDto response = new PaymentResponseDto();
         response.setReceiptId(request.getReceiptId());
         response.setReservationId(reservation.getId());
@@ -56,5 +67,22 @@ public class PaymentService {
     private static Long generateUniqueReservationCode() {
         return Math.abs(UUID.randomUUID().getMostSignificantBits() & Long.MAX_VALUE);
     }
-    
+
+    // 🎯 좌석 문자열을 파싱하여 Seat 객체 리스트로 변환
+    private List<Seat> parseSeatNames(String seatNames, Long playingId, Long reservationId) {
+        if (seatNames == null || seatNames.trim().isEmpty()) {
+            return List.of();
+        }
+
+        return Arrays.stream(seatNames.split(","))
+                .map(String::trim)
+                .map(seatName -> {
+                    Seat seat = new Seat();
+                    seat.setName(seatName);
+                    seat.setPlayingId(playingId);
+                    seat.setReservationId(reservationId);
+                    return seat;
+                })
+                .collect(Collectors.toList());
+    }
 }

--- a/metanet4/src/main/java/com/metanet/team4/payment/service/PaymentService.java
+++ b/metanet4/src/main/java/com/metanet/team4/payment/service/PaymentService.java
@@ -40,7 +40,7 @@ public class PaymentService {
     	
     	reservation.setMemberId(member.getId());
     	reservation.setPlayingId(request.getPlayingId());
-    	reservation.setSeatId(1L); // Todo 생성하고 넣는걸로 수정 해야함
+//    	reservation.setSeatId(1L); // Todo 생성하고 넣는걸로 수정 해야함
     	
     	reservationRepository.insertReservation(reservation);
     	

--- a/metanet4/src/main/java/com/metanet/team4/payment/service/ReservService.java
+++ b/metanet4/src/main/java/com/metanet/team4/payment/service/ReservService.java
@@ -17,14 +17,20 @@ public class ReservService {
 	private final IReservatoinRepository repository;
 	
 	@Transactional
-    public ReservationDetailDto getReservationDetail(Long reservationId) {
-        return repository.getReservationDetail(reservationId);
+    public ReservationDetailDto getReservationDetail(Long userId, Long reservationId) {
+		Reservation reservation = repository.getReservationByUserIdAndId(userId, reservationId);
+        if (reservation == null) {
+            throw new RuntimeException("해당 예약 정보를 찾을 수 없습니다. reservationId: " + reservationId);
+        }
+        ReservationDetailDto reservationDetailDto = repository.getReservationDetail(reservationId);
+        reservationDetailDto.setSeatList(reservation.getSeatList());
+        return reservationDetailDto;
     }
     
     @Transactional
     public CancelResponseDto cancelReservation(Long userId, Long reservationId) {
     	
-        Reservation reservation = repository.getReervationByUserIdAndId(userId, reservationId);
+        Reservation reservation = repository.getReservationByUserIdAndId(userId, reservationId);
         if (reservation == null) {
             throw new RuntimeException("해당 예약 정보를 찾을 수 없습니다. reservationId: " + reservationId);
         }

--- a/metanet4/src/main/java/com/metanet/team4/ticket/controller/TicketController.java
+++ b/metanet4/src/main/java/com/metanet/team4/ticket/controller/TicketController.java
@@ -1,6 +1,5 @@
 package com.metanet.team4.ticket.controller;
 
-import java.sql.Date;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
@@ -10,13 +9,14 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.CrossOrigin;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.metanet.team4.ticket.dto.CinemaFindResponseDto;
+import com.metanet.team4.ticket.dto.PlayingResponseDto;
 import com.metanet.team4.ticket.dto.ScreenFindResponseDto;
 import com.metanet.team4.ticket.dto.SeatResponseDto;
 import com.metanet.team4.ticket.dto.TicketRequestDto;
@@ -74,4 +74,11 @@ public class TicketController {
 		return ResponseEntity.status(HttpStatus.OK).body(ticketList);
 	}
 	
+	//상영 Id로 데이터 조회
+    @GetMapping("/playing/{playingId}")
+    @Operation(summary="상영 정보 조회", description="playingId를 기반으로 영화, 상영시간, 좌석 정보를 조회")
+    public ResponseEntity<PlayingResponseDto> getPlayingInfo(@PathVariable Long playingId) {
+    	PlayingResponseDto response = ticketService.findPlayingInfo(playingId);
+        return ResponseEntity.status(HttpStatus.OK).body(response);
+    }
 }

--- a/metanet4/src/main/java/com/metanet/team4/ticket/dao/ISeatRepository.java
+++ b/metanet4/src/main/java/com/metanet/team4/ticket/dao/ISeatRepository.java
@@ -1,0 +1,13 @@
+package com.metanet.team4.ticket.dao;
+
+import java.util.List;
+
+import org.apache.ibatis.annotations.Mapper;
+
+import com.metanet.team4.ticket.model.Seat;
+
+@Mapper
+public interface ISeatRepository {
+
+	void insertSeat(Seat seats);
+}

--- a/metanet4/src/main/java/com/metanet/team4/ticket/dao/ITicketRepository.java
+++ b/metanet4/src/main/java/com/metanet/team4/ticket/dao/ITicketRepository.java
@@ -6,6 +6,7 @@ import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Select;
 
 import com.metanet.team4.ticket.dto.CinemaFindResponseDto;
+import com.metanet.team4.ticket.dto.PlayingResponseDto;
 import com.metanet.team4.ticket.dto.ScreenFindResponseDto;
 import com.metanet.team4.ticket.dto.SeatResponseDto;
 import com.metanet.team4.ticket.dto.TicketResponseDto;
@@ -97,5 +98,22 @@ public interface ITicketRepository {
 			+ "  AND sc.id = #{screenId}")
 	List<TicketResponseDto> findReserveInfo(Long playingId, Long screenId);
 	
-	
+    @Select("""
+            SELECT 
+                m.krName AS krName,
+                m.watch_grade AS watchGrade,
+                TO_CHAR(p.playing_date, 'YYYY-MM-DD') || ' (' || 
+                TO_CHAR(p.start_time, 'HH24:MI') || ' ~ ' || 
+                TO_CHAR(p.end_time, 'HH24:MI') || ')' AS playingTime,
+                c.name AS cinemaName,
+                sc.name AS screenName
+            FROM playing p
+            JOIN movie m ON p.movie_id = m.id
+            JOIN screen sc ON p.screen_id = sc.id
+            JOIN cinema c ON sc.cinema_id = c.id
+            WHERE p.id = #{playingId}
+        """)
+        PlayingResponseDto findPlayingInfo(Long playingId);
+
+
 }

--- a/metanet4/src/main/java/com/metanet/team4/ticket/dto/PlayingResponseDto.java
+++ b/metanet4/src/main/java/com/metanet/team4/ticket/dto/PlayingResponseDto.java
@@ -1,0 +1,16 @@
+package com.metanet.team4.ticket.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class PlayingResponseDto {
+    private String krName;       // 영화 제목
+    private String watchGrade;   // 연령 제한
+    private String playingTime;  // 상영 시간 (날짜 + 시작시간 ~ 종료시간)
+    private String cinemaName;   // 영화관 이름
+    private String screenName;   // 상영관 이름
+}

--- a/metanet4/src/main/java/com/metanet/team4/ticket/model/Seat.java
+++ b/metanet4/src/main/java/com/metanet/team4/ticket/model/Seat.java
@@ -7,4 +7,5 @@ public class Seat {
 	private Long id;
 	private String name;
 	private Long screenId;
+	private Long reservationId;
 }

--- a/metanet4/src/main/java/com/metanet/team4/ticket/model/Seat.java
+++ b/metanet4/src/main/java/com/metanet/team4/ticket/model/Seat.java
@@ -1,11 +1,13 @@
 package com.metanet.team4.ticket.model;
 
 import lombok.Getter;
+import lombok.Setter;
 
 @Getter
+@Setter
 public class Seat {
 	private Long id;
 	private String name;
-	private Long screenId;
+	private Long playingId;
 	private Long reservationId;
 }

--- a/metanet4/src/main/java/com/metanet/team4/ticket/service/ITicketService.java
+++ b/metanet4/src/main/java/com/metanet/team4/ticket/service/ITicketService.java
@@ -5,6 +5,7 @@ import java.util.List;
 import java.util.Map;
 
 import com.metanet.team4.ticket.dto.CinemaFindResponseDto;
+import com.metanet.team4.ticket.dto.PlayingResponseDto;
 import com.metanet.team4.ticket.dto.ScreenFindResponseDto;
 import com.metanet.team4.ticket.dto.SeatResponseDto;
 import com.metanet.team4.ticket.dto.TicketRequestDto;
@@ -17,4 +18,5 @@ public interface ITicketService {
 	List<SeatResponseDto> findSeatList(Long playingId);
 	List<TicketResponseDto> getSeatInfo(TicketRequestDto ticketReqeustDto, List<TimeDto> timeList);
 	List<TimeDto> getTimeDtoList(Long id);
+	PlayingResponseDto findPlayingInfo(Long playingId);
 }

--- a/metanet4/src/main/java/com/metanet/team4/ticket/service/TicketService.java
+++ b/metanet4/src/main/java/com/metanet/team4/ticket/service/TicketService.java
@@ -1,6 +1,5 @@
 package com.metanet.team4.ticket.service;
 
-import java.sql.Date;
 import java.text.SimpleDateFormat;
 import java.time.LocalDateTime;
 import java.util.List;
@@ -12,6 +11,7 @@ import org.springframework.stereotype.Service;
 
 import com.metanet.team4.ticket.dao.ITicketRepository;
 import com.metanet.team4.ticket.dto.CinemaFindResponseDto;
+import com.metanet.team4.ticket.dto.PlayingResponseDto;
 import com.metanet.team4.ticket.dto.ScreenFindResponseDto;
 import com.metanet.team4.ticket.dto.SeatResponseDto;
 import com.metanet.team4.ticket.dto.TicketRequestDto;
@@ -73,5 +73,9 @@ public class TicketService implements ITicketService{
 	}
 
 
+    @Override
+    public PlayingResponseDto findPlayingInfo(Long playingId) {
+        return iTicketRepository.findPlayingInfo(playingId);
+    }
 
 }

--- a/metanet4/src/main/resources/mapper/ReservationMapper.xml
+++ b/metanet4/src/main/resources/mapper/ReservationMapper.xml
@@ -4,22 +4,46 @@
 
 <mapper namespace="com.metanet.team4.payment.dao.IReservatoinRepository">
 	
-	<select id="getReervationByUserIdAndId" parameterType="map" resultType="com.metanet.team4.payment.model.Reservation">
+	<select id="getReservationByUserIdAndId" parameterType="map" resultMap="reservationResultMap">
 	    SELECT 
-	        ID, 
-	        RESERVATION_CODE, 
-	        RESERVATION_TIME, 
-	        PAYMENT_AMOUNT, 
-	        TICKET_TYPE, 
-	        TICKET_STATUS, 
-	        RECEIPT_ID, 
-	        MEMBER_ID, 
-	        PLAYING_ID
-	    FROM RESERVATION
-	    WHERE MEMBER_ID = #{userId} 
-	   		AND ID = #{reservationId}
+	        r.ID, 
+	        r.RESERVATION_CODE, 
+	        r.RESERVATION_TIME, 
+	        r.PAYMENT_AMOUNT, 
+	        r.TICKET_TYPE, 
+	        r.TICKET_STATUS, 
+	        r.RECEIPT_ID, 
+	        r.MEMBER_ID, 
+	        r.PLAYING_ID,
+	        s.ID AS seat_id, 
+	        s.NAME AS seat_name,
+	        s.PLAYING_ID AS seat_playing_id, 
+	        s.RESERVATION_ID AS seat_reservation_id
+	    FROM RESERVATION r
+	    LEFT JOIN SEAT s ON r.ID = s.RESERVATION_ID
+	    WHERE r.MEMBER_ID = #{userId} 
+	      AND r.ID = #{reservationId}
 	</select>
-
+	
+	<resultMap id="reservationResultMap" type="com.metanet.team4.payment.model.Reservation">
+	    <id property="id" column="ID"/>
+	    <result property="reservationCode" column="RESERVATION_CODE"/>
+	    <result property="reservationTime" column="RESERVATION_TIME"/>
+	    <result property="paymentAmount" column="PAYMENT_AMOUNT"/>
+	    <result property="ticketType" column="TICKET_TYPE"/>
+	    <result property="ticketStatus" column="TICKET_STATUS"/>
+	    <result property="receiptId" column="RECEIPT_ID"/>
+	    <result property="memberId" column="MEMBER_ID"/>
+	    <result property="playingId" column="PLAYING_ID"/>
+	    
+	    <!-- Seat 리스트 매핑 -->
+	    <collection property="seatList" ofType="com.metanet.team4.ticket.model.Seat">
+	        <id property="id" column="seat_id"/>
+	        <result property="name" column="seat_name"/>
+	        <result property="playingId" column="seat_playing_id"/>
+	        <result property="reservationId" column="seat_reservation_id"/>
+	    </collection>
+	</resultMap>
 
 	<insert id="insertReservation" parameterType="com.metanet.team4.payment.model.Reservation">
 		<selectKey keyProperty="id" resultType="Long" order="BEFORE">

--- a/metanet4/src/main/resources/mapper/ReservationMapper.xml
+++ b/metanet4/src/main/resources/mapper/ReservationMapper.xml
@@ -14,8 +14,7 @@
 	        TICKET_STATUS, 
 	        RECEIPT_ID, 
 	        MEMBER_ID, 
-	        PLAYING_ID, 
-	        SEAT_ID
+	        PLAYING_ID
 	    FROM RESERVATION
 	    WHERE MEMBER_ID = #{userId} 
 	   		AND ID = #{reservationId}
@@ -35,8 +34,7 @@
 	        TICKET_STATUS, 
 	        RECEIPT_ID, 
 	        MEMBER_ID, 
-	        PLAYING_ID, 
-	        SEAT_ID
+	        PLAYING_ID
 	    ) VALUES (
 	        #{id},
 	        #{reservationCode}, 
@@ -46,8 +44,7 @@
 	        #{ticketStatus}, 
 	        #{receiptId}, 
 	        #{memberId}, 
-	        #{playingId}, 
-	        #{seatId}
+	        #{playingId}
 	    )
 	</insert>
 
@@ -62,7 +59,6 @@
             p.end_time           AS endTime,
             c.name               AS cinemaName,
             sc.name              AS screenName,
-            st.name              AS seatName,
             r.ticket_type        AS ticketType,
             r.reservation_code   AS reservationCode
         FROM Reservation r
@@ -70,7 +66,6 @@
              JOIN screen sc  ON p.screen_id = sc.id
              JOIN cinema c   ON sc.cinema_id = c.id
              JOIN movie m    ON p.movie_id = m.id
-             JOIN seat st    ON r.seat_id = st.id
         WHERE r.id = #{reservationId}
     </select>
 

--- a/metanet4/src/main/resources/mapper/SeatMapper.xml
+++ b/metanet4/src/main/resources/mapper/SeatMapper.xml
@@ -2,7 +2,11 @@
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
         "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
 
-<mapper namespace="com.metanet.team4.payment.dao.IReservatoinRepository">
+<mapper namespace="com.metanet.team4.ticket.dao.ISeatRepository">
 
-	
+<insert id="insertSeat" parameterType="com.metanet.team4.ticket.model.Seat">
+        INSERT INTO Seat (id, name, playing_id, reservation_id)
+        VALUES (SEAT_SEQ.NEXTVAL, #{name}, #{playingId}, #{reservationId})
+</insert>
+
 </mapper>

--- a/metanet4/src/main/resources/mapper/SeatMapper.xml
+++ b/metanet4/src/main/resources/mapper/SeatMapper.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="com.metanet.team4.payment.dao.IReservatoinRepository">
+
+	
+</mapper>

--- a/metanet4/src/test/java/com/metanet/team4/ticket/controller/TicketControllerTest.java
+++ b/metanet4/src/test/java/com/metanet/team4/ticket/controller/TicketControllerTest.java
@@ -1,0 +1,82 @@
+package com.metanet.team4.ticket.controller;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.metanet.team4.common.LoginResponseDto;
+import com.metanet.team4.common.TestDataUtils;
+import com.metanet.team4.member.model.Member;
+
+import jakarta.servlet.http.Cookie;
+
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ExtendWith(SpringExtension.class)
+@Transactional
+class TicketControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+    
+    @Autowired
+    private TestDataUtils testDataUtils;
+    
+    private String token;
+    private Member member;
+    
+    @BeforeEach
+    void beforeEach() {
+    	LoginResponseDto loginResponseDto = testDataUtils.getLoginAccessToken();
+    	token = loginResponseDto.getToken();
+    	member = loginResponseDto.getMember();
+    }
+	
+//	@Test
+//	void testGetCinemaList() {
+//		fail("Not yet implemented");
+//	}
+//
+//	@Test
+//	void testGetPlayingList() {
+//		fail("Not yet implemented");
+//	}
+//
+//	@Test
+//	void testGetSeatList() {
+//		fail("Not yet implemented");
+//	}
+//
+//	@Test
+//	void testPostSeatInfo() {
+//		fail("Not yet implemented");
+//	}
+
+	@Test
+	@DisplayName("상영정보 조회 테스트")
+	void testGetPlayingInfo() throws Exception {
+	    // given
+
+        // when & then
+        mockMvc.perform(get("/ticket/playing/1")
+        		.cookie(new Cookie("jwt", token)))
+               .andExpect(status().isOk());
+	}
+
+}


### PR DESCRIPTION
## ⭐Key Changes

1. seat 테이블에 예매id추가
2. 상영id로 상영 정보 가져오는 api 추가
3. 예매시 좌석 데이터 생성하고 저장 하는 코드 추가
4. 예매 상세 조회 시에 좌석 리스트 리턴 되도록 수정


## 📌 issue

close #76 